### PR TITLE
Add error catching for opening port

### DIFF
--- a/run_control.js
+++ b/run_control.js
@@ -91,8 +91,16 @@ async function connectAndStart() {
 
     // Open the serial port
     console.log("Opening port");
-    await port.open({ baudRate: 115200, baudrate: 115200 });
-    // yes - you need both if you want it to run on Chromebooks
+    try {
+        await port.open({ baudRate: 115200, baudrate: 115200 });
+        // yes - you need both if you want it to run on Chromebooks
+    } catch (e) {
+        alert(
+            "Failed to establish connection to the port: " +
+            "make sure that your computer user has access to the IOLab dongle."
+        );
+        return false;
+    }
 
     // Create a reader and a writer
     writer = port.writable.getWriter();


### PR DESCRIPTION
The current `port.open()` call will fail silently if a user tries connecting to the IOLab dongle when they have insufficient permission.

I caught this error on Linux where IOLab dongle is not accessible to non-root user by default:
```
$ ls -l /dev/ttyACM* 
crw-rw---- 1 root uucp 166, 0 Jan 26 14:42 /dev/ttyACM0
```
On Linux, this can be fixed by running:
```
chown :$USER /dev/ttyACM*
```
This PR adds an `alert()` and error catching for `port.open()` failure, ensuring that the error is relayed properly to the IOLabWeb user when it occurs.